### PR TITLE
chore(renovate): adopt BarretoTech shared config (monthly schedule)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>BarretoTech/renovate-config"]
+}


### PR DESCRIPTION
Re-points this repo's Renovate config to the new org-wide shared preset at `BarretoTech/renovate-config`.

**Effect:**
- PRs from Renovate will now only be created on the **last Sunday of each month** (between the 25th and 31st, before 6am Europe/Berlin) instead of daily.
- Inherits the full set of grouping, automerge, security, and `.prototools` rules from the shared config.
- Security/vulnerability PRs still ship immediately (they override the monthly schedule).

Part of consolidating Renovate noise across the BarretoTech org.